### PR TITLE
Add callback failed fetch toggle and keep existing toggle if fetch from server failed

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/screens/basic_usage_screen.dart';
+import 'package:example/screens/toggle_list_screen.dart';
 import 'package:example/screens/update_context_screen.dart';
 import 'package:example/unleash_environment.dart';
 import 'package:flutter/material.dart';
@@ -66,6 +67,14 @@ class _UnleashPageState extends State<UnleashPage> {
                     builder: (context) => BasicUsageScreen(app: widget.app),
                   )),
               child: const Text('Basic Usage'),
+            ),
+            OutlinedButton(
+              onPressed: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ToggleListScreen(app: widget.app),
+                  )),
+              child: const Text('Toggle list'),
             ),
             OutlinedButton(
               onPressed: () => Navigator.push(

--- a/example/lib/screens/toggle_list_screen.dart
+++ b/example/lib/screens/toggle_list_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:unleash_proxy/unleash_proxy.dart';
+
+class ToggleListScreen extends StatelessWidget {
+  const ToggleListScreen({super.key, required this.app});
+
+  final UnleashApp app;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Toggle list screen'),
+      ),
+      body: ListView.separated(
+        itemBuilder: (context, index) => _toggleTile(
+          index: index,
+        ),
+        itemCount: app.toggles?.length ?? 0,
+        separatorBuilder: (context, index) => const Divider(
+          thickness: 1,
+          color: Colors.grey,
+        ),
+      ),
+    );
+  }
+
+  Widget _toggleTile({required int index}) {
+    final toggle = app.toggles?[index];
+    if (toggle == null) {
+      return const SizedBox(
+        width: 0,
+        height: 0,
+      );
+    }
+    return ListTile(
+      title: Text(toggle.name),
+      subtitle: Text(toggle.enabled == true ? 'Enabled' : 'Disabled'),
+    );
+  }
+}

--- a/example/lib/unleash_environment.dart
+++ b/example/lib/unleash_environment.dart
@@ -7,23 +7,25 @@ class UnleashEnvironment {
     final String source = await rootBundle.loadString('lib/source.json');
 
     return UnleashOptions(
-      proxyUrl: 'https://app.unleash-hosted.com/demo/api/proxy',
-      clientKey: 'proxy-123',
-      poolMode: const Duration(seconds: 5),
-      bootstrap: UnleashBootstrap(
-        source: [
-          UnleashToggle(
-            enabled: true,
-            name: 'testing-source',
-            variant: UnleashToggleVariant(name: 'disabled', enabled: false),
-          ),
-        ],
-        json: source,
-      ),
-      onFetched: (List<UnleashToggle> toggles) {
-        debugPrint('Yay! ${toggles.length} toggles fetched.');
-      },
-    );
+        proxyUrl: 'https://app.unleash-hosted.com/demo/api/proxy',
+        clientKey: 'proxy-123',
+        poolMode: const Duration(seconds: 5),
+        bootstrap: UnleashBootstrap(
+          source: [
+            UnleashToggle(
+              enabled: true,
+              name: 'testing-source',
+              variant: UnleashToggleVariant(name: 'disabled', enabled: false),
+            ),
+          ],
+          json: source,
+        ),
+        onFetchedSuccess: (List<UnleashToggle> toggles) {
+          debugPrint('Yay! ${toggles.length} toggles fetched.');
+        },
+        onFetchedFailed: (Exception e) {
+          debugPrint('Ouch! failed to fetch toggles with error: $e.');
+        });
   }
 
   static UnleashContext get context => UnleashContext(

--- a/lib/src/data/result.dart
+++ b/lib/src/data/result.dart
@@ -1,0 +1,32 @@
+/// Result class to handle fetch success or failure from server
+abstract class Result<T> {}
+
+/// Wrap successful fetch result
+class Success<T> extends Result<T> {
+  /// Constructor to wrap data from successful fetch
+  Success(this._data);
+
+  final T? _data;
+
+  /// Getter for data of successful fetch
+  T? get data => _data;
+}
+
+/// Wrap failed fetch result
+class Error<T> extends Result<T> {
+  /// Constructor to convert object to exception
+  Error(Object error) {
+    if (error is Exception) {
+      _error = error;
+    } else {
+      // to prevent stack overflow just print the class name
+      // if the error class is unknown
+      final message = error is String ? error : error.runtimeType.toString();
+      _error = Exception('Unknown error: $message');
+    }
+  }
+  late final Exception _error;
+
+  /// Getter for exception of failed fetch
+  Exception get error => _error;
+}

--- a/lib/src/interfaces/options.dart
+++ b/lib/src/interfaces/options.dart
@@ -35,13 +35,9 @@ class UnleashOptions {
         'Content-Type': 'application/json',
       };
 
-  /// [onFetchedSuccess] is not supported yet.
-  ///
   /// Run this function every successful fetch from server
   final void Function(List<UnleashToggle> toggles)? onFetchedSuccess;
 
-  /// [onFetchedFailed] is not supported yet.
-  ///
   /// Run this function every failed fetch from server
   final void Function(Exception e)? onFetchedFailed;
 }

--- a/lib/src/interfaces/options.dart
+++ b/lib/src/interfaces/options.dart
@@ -9,7 +9,8 @@ class UnleashOptions {
     this.instanceId,
     this.poolMode = const Duration(seconds: 15),
     this.bootstrap,
-    this.onFetched,
+    this.onFetchedSuccess,
+    this.onFetchedFailed,
   });
 
   /// Unleash Proxy URL
@@ -34,8 +35,13 @@ class UnleashOptions {
         'Content-Type': 'application/json',
       };
 
-  /// [onFetched] is not supported yet.
+  /// [onFetchedSuccess] is not supported yet.
   ///
-  /// Run this function every fetch from server
-  final void Function(List<UnleashToggle> toggles)? onFetched;
+  /// Run this function every successful fetch from server
+  final void Function(List<UnleashToggle> toggles)? onFetchedSuccess;
+
+  /// [onFetchedFailed] is not supported yet.
+  ///
+  /// Run this function every failed fetch from server
+  final void Function(Exception e)? onFetchedFailed;
 }

--- a/lib/src/unleash_app/unleash_app_method_channel.dart
+++ b/lib/src/unleash_app/unleash_app_method_channel.dart
@@ -80,12 +80,12 @@ class MethodChannelUnleashApp extends UnleashAppPlatform {
         error: fetchResult.error,
       );
 
-      /// return unmodified toggles or empty
+      /// return unmodified toggles or bootstrap toggles
       return toggles ?? _fetchFromBootstrap();
     }
 
     /// should not reach this lines, but by default return unmodified toggles
-    /// or empty
+    /// or bootstrap toggles
     return toggles ?? _fetchFromBootstrap();
   }
 

--- a/lib/src/unleash_app/unleash_app_method_channel.dart
+++ b/lib/src/unleash_app/unleash_app_method_channel.dart
@@ -81,12 +81,12 @@ class MethodChannelUnleashApp extends UnleashAppPlatform {
       );
 
       /// return unmodified toggles or empty
-      return toggles ?? [];
+      return toggles ?? _fetchFromBootstrap();
     }
 
     /// should not reach this lines, but by default return unmodified toggles
     /// or empty
-    return toggles ?? [];
+    return toggles ?? _fetchFromBootstrap();
   }
 
   Future<Result<List<UnleashToggle>?>> _fetchFromServer({


### PR DESCRIPTION
## Status

**READY**

## Description

- add `onFetchedSuccess` and `onFetchedFailed` callback instead of only `onFetched` callback for better error handling
- keep already fetched toggle if next fetch is failed instead of replace it all with bootstrapped value.
- add toggle list screen in example project

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Evidence 

**Before** 

Log always success even when fetch failed  : 

<img width="436" alt="Screen Shot 2023-06-13 at 14 32 13" src="https://github.com/rizentium/unleash-flutter-proxy-sdk/assets/10940190/89456077-5bed-4168-b2d8-5d246cb21352">

Toggle replaced with bootstrap value when fetch failed : 

https://github.com/rizentium/unleash-flutter-proxy-sdk/assets/10940190/6e2d56b7-fa38-467e-ae2a-762455b99af6


**After**

We can log failed fetch with the new callback : 

<img width="868" alt="Screen Shot 2023-06-13 at 14 33 54" src="https://github.com/rizentium/unleash-flutter-proxy-sdk/assets/10940190/883117de-ce99-4f35-9ba5-c0beaea311bf">

Existing toggle not replaced when fetch failed :

https://github.com/rizentium/unleash-flutter-proxy-sdk/assets/10940190/73173c18-43ed-4ec6-902c-66cf57c41b25

